### PR TITLE
更新tensorflow的macOS下载版本到最新的v1.5.0

### DIFF
--- a/SOURCE/get_started/os_setup.md
+++ b/SOURCE/get_started/os_setup.md
@@ -30,7 +30,7 @@ $ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/linux/gpu
 
 # Mac OS X, CPU only:
 $ sudo easy_install --upgrade six
-$ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0-py2-none-any.whl
+$ sudo pip install --upgrade https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.5.0rc1-py2-none-any.whl
 ```
 
 如果是 Python3 :


### PR DESCRIPTION
参考：https://www.tensorflow.org/versions/r1.5/install/install_mac